### PR TITLE
Remove confusing 404 error message

### DIFF
--- a/src/http/stream.ts
+++ b/src/http/stream.ts
@@ -473,9 +473,5 @@ async function errorFromResponse(resp: Response): Promise<Error> {
         }
     }
 
-    if (resp.status === 404) {
-        message += ". It seems that the libsql server is outdated, please try updating the database.";
-    }
-
     return new HttpServerError(message, resp.status);
 }


### PR DESCRIPTION
In order to fix [Issue #189](https://github.com/tursodatabase/libsql-client-ts/issues/189) in `libsql-client-ts`, this additional error message should be removed.

**Before:**
```
LibsqlError: SERVER_ERROR: Server returned HTTP status 404. It seems that the libsql server is outdated, please try updating the database.
```

**After:**
```
LibsqlError: SERVER_ERROR: Server returned HTTP status 404
```

Let me know if you want me to also bump `hrana-client` once this is merged & publish.