### PR TITLE
Make row properties writable to match the behavior of the sqlite client

### DIFF
--- a/src/result.ts
+++ b/src/result.ts
@@ -90,7 +90,7 @@ function rowFromProto(
 
         const colName = colNames[i];
         if (colName !== undefined && !Object.hasOwn(row, colName)) {
-            Object.defineProperty(row, colName, { value, enumerable: true });
+            Object.defineProperty(row, colName, { value, enumerable: true, configurable: true, writable: true });
         }
     }
     return row as Row;


### PR DESCRIPTION
In [@libsql/client](https://github.com/tursodatabase/libsql-client-ts/blob/b58d509e0bf0a48b28e7bd02ae2708fcb62a1f22/packages/libsql-client/src/sqlite3.ts#L275), column properties on rows are defined with `writable: true`.

```ts
Object.defineProperty(row, column, { value, enumerable: true, configurable: true, writable: true });
```

This was fixed in https://github.com/tursodatabase/libsql-client-ts/pull/166, but not in this repository.