### PR TITLE
Client config for boolean casting

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -3,11 +3,15 @@ import type { IntMode } from "./value.js";
 
 export type ProtocolVersion = 1 | 2 | 3;
 export type ProtocolEncoding = "json" | "protobuf";
+export type ClientConfig = {
+    castBooleans?: boolean;
+};
 
 /** A client for the Hrana protocol (a "database connection pool"). */
 export abstract class Client {
     /** @private */
-    constructor() {
+    constructor(config: ClientConfig) {
+        this.config = config;
         this.intMode = "number";
     }
 
@@ -36,4 +40,7 @@ export abstract class Client {
      * override the integer mode for every stream by setting {@link Stream.intMode} on the stream.
      */
     intMode: IntMode;
+
+    /** Stores the client configuration. See {@link ClientConfig}. */
+    config: ClientConfig;
 }

--- a/src/http/client.ts
+++ b/src/http/client.ts
@@ -1,6 +1,6 @@
 import { fetch, Request } from "@libsql/isomorphic-fetch";
 
-import type { ProtocolVersion, ProtocolEncoding } from "../client.js";
+import type { ProtocolVersion, ProtocolEncoding, ClientConfig } from "../client.js";
 import { Client } from "../client.js";
 import { ClientError, ClosedError, ProtocolVersionError } from "../errors.js";
 
@@ -56,8 +56,8 @@ export class HttpClient extends Client {
     _endpoint: Endpoint | undefined;
 
     /** @private */
-    constructor(url: URL, jwt: string | undefined, customFetch: unknown | undefined, protocolVersion: ProtocolVersion = 2) {
-        super();
+    constructor(url: URL, jwt: string | undefined, customFetch: unknown | undefined, protocolVersion: ProtocolVersion = 2, config: ClientConfig) {
+        super(config);
         this.#url = url;
         this.#jwt = jwt;
         this.#fetch = (customFetch as typeof fetch) ?? fetch;

--- a/src/http/stream.ts
+++ b/src/http/stream.ts
@@ -66,7 +66,7 @@ export class HttpStream extends Stream implements SqlOwner {
 
     /** @private */
     constructor(client: HttpClient, baseUrl: URL, jwt: string | undefined, customFetch: typeof fetch) {
-        super(client.intMode);
+        super(client.intMode, client.config);
         this.#client = client;
         this.#baseUrl = baseUrl.toString();
         this.#jwt = jwt;

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,13 +5,13 @@ import { WebSocketUnsupportedError } from "./errors.js";
 
 import { HttpClient } from "./http/client.js";
 import { WsClient } from "./ws/client.js";
-import { ProtocolVersion } from "./client.js";
+import { ClientConfig, ProtocolVersion } from "./client.js";
 
 export { WebSocket } from "@libsql/isomorphic-ws";
 export type { RequestInit, Response } from "@libsql/isomorphic-fetch";
 export { fetch, Request, Headers } from "@libsql/isomorphic-fetch";
 
-export type { ProtocolVersion, ProtocolEncoding } from "./client.js";
+export type { ClientConfig, ProtocolVersion, ProtocolEncoding } from "./client.js";
 export { Client } from "./client.js";
 export type { DescribeResult, DescribeColumn } from "./describe.js";
 export * from "./errors.js";
@@ -32,7 +32,7 @@ export { WsClient } from "./ws/client.js";
 export { WsStream } from "./ws/stream.js";
 
 /** Open a Hrana client over WebSocket connected to the given `url`. */
-export function openWs(url: string | URL, jwt?: string, protocolVersion: ProtocolVersion = 2): WsClient {
+export function openWs(url: string | URL, jwt?: string, protocolVersion: ProtocolVersion = 2, config: ClientConfig = {}): WsClient {
     if (typeof WebSocket === "undefined") {
         throw new WebSocketUnsupportedError("WebSockets are not supported in this environment");
     }
@@ -43,7 +43,7 @@ export function openWs(url: string | URL, jwt?: string, protocolVersion: Protoco
         subprotocols = Array.from(subprotocolsV2.keys());
     }
     const socket = new WebSocket(url, subprotocols);
-    return new WsClient(socket, jwt);
+    return new WsClient(socket, jwt, config);
 }
 
 /** Open a Hrana client over HTTP connected to the given `url`.
@@ -52,6 +52,6 @@ export function openWs(url: string | URL, jwt?: string, protocolVersion: Protoco
  * from `@libsql/isomorphic-fetch`. This function is always called with a `Request` object from
  * `@libsql/isomorphic-fetch`.
  */
-export function openHttp(url: string | URL, jwt?: string, customFetch?: unknown | undefined, protocolVersion: ProtocolVersion = 2): HttpClient {
-    return new HttpClient(url instanceof URL ? url : new URL(url), jwt, customFetch, protocolVersion);
+export function openHttp(url: string | URL, jwt?: string, customFetch?: unknown | undefined, protocolVersion: ProtocolVersion = 2, config: ClientConfig = {}): HttpClient {
+    return new HttpClient(url instanceof URL ? url : new URL(url), jwt, customFetch, protocolVersion, config);
 }

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1,5 +1,5 @@
 import { Batch } from "./batch.js";
-import type { Client } from "./client.js";
+import type { Client, ClientConfig } from "./client.js";
 import type { Cursor } from "./cursor.js";
 import type { DescribeResult } from "./describe.js";
 import { describeResultFromProto } from "./describe.js";
@@ -18,8 +18,9 @@ import type { IntMode } from "./value.js";
 /** A stream for executing SQL statements (a "database connection"). */
 export abstract class Stream {
     /** @private */
-    constructor(intMode: IntMode) {
+    constructor(intMode: IntMode, config: ClientConfig) {
         this.intMode = intMode;
+        this.config = config;
     }
 
     /** Get the client object that this stream belongs to. */
@@ -61,10 +62,10 @@ export abstract class Stream {
     #execute<T>(
         inStmt: InStmt,
         wantRows: boolean,
-        fromProto: (result: proto.StmtResult, intMode: IntMode) => T,
+        fromProto: (result: proto.StmtResult, intMode: IntMode, config: ClientConfig) => T,
     ): Promise<T> {
         const stmt = stmtToProto(this._sqlOwner(), inStmt, wantRows);
-        return this._execute(stmt).then((r) => fromProto(r, this.intMode));
+        return this._execute(stmt).then((r) => fromProto(r, this.intMode, this.config));
     }
 
     /** Return a builder for creating and executing a batch.
@@ -120,4 +121,7 @@ export abstract class Stream {
      * This value affects the results of all operations on this stream.
      */
     intMode: IntMode;
+
+    /** Stores the client configuration. */
+    config: ClientConfig;
 }

--- a/src/value.ts
+++ b/src/value.ts
@@ -1,4 +1,4 @@
-import { ClientError, ProtoError, MisuseError } from "./errors.js";
+import { ProtoError, MisuseError } from "./errors.js";
 import type * as proto from "./shared/proto.js";
 import { impossible } from "./util.js";
 
@@ -7,6 +7,7 @@ export type Value =
     | null
     | string
     | number
+    | boolean
     | bigint
     | ArrayBuffer
 
@@ -65,7 +66,7 @@ export function valueToProto(value: InValue): proto.Value {
 const minInteger = -9223372036854775808n;
 const maxInteger = 9223372036854775807n;
 
-export function valueFromProto(value: proto.Value, intMode: IntMode): Value {
+export function valueFromProto(value: proto.Value, intMode: IntMode, colDecltype?: string, castBooleans?: boolean): Value {
     if (value === null) {
         return null;
     } else if (typeof value === "number") {
@@ -73,6 +74,9 @@ export function valueFromProto(value: proto.Value, intMode: IntMode): Value {
     } else if (typeof value === "string") {
         return value;
     } else if (typeof value === "bigint") {
+        if (castBooleans && colDecltype === 'boolean') {
+            return Boolean(value);
+        }
         if (intMode === "number") {
             const num = Number(value);
             if (!Number.isSafeInteger(num)) {

--- a/src/value.ts
+++ b/src/value.ts
@@ -74,7 +74,7 @@ export function valueFromProto(value: proto.Value, intMode: IntMode, colDecltype
     } else if (typeof value === "string") {
         return value;
     } else if (typeof value === "bigint") {
-        if (castBooleans && colDecltype === 'boolean') {
+        if (castBooleans && colDecltype?.toLowerCase() === 'boolean') {
             return Boolean(value);
         }
         if (intMode === "number") {

--- a/src/ws/client.ts
+++ b/src/ws/client.ts
@@ -1,6 +1,6 @@
 import { WebSocket } from "@libsql/isomorphic-ws";
 
-import type { ProtocolVersion, ProtocolEncoding } from "../client.js";
+import type { ProtocolVersion, ProtocolEncoding, ClientConfig } from "../client.js";
 import { Client } from "../client.js";
 import {
     readJsonObject, writeJsonObject, readProtobufMessage, writeProtobufMessage,
@@ -73,8 +73,8 @@ export class WsClient extends Client implements SqlOwner {
     #sqlIdAlloc: IdAlloc;
 
     /** @private */
-    constructor(socket: WebSocket, jwt: string | undefined) {
-        super();
+    constructor(socket: WebSocket, jwt: string | undefined, config: ClientConfig) {
+        super(config);
 
         this.#socket = socket;
         this.#openCallbacks = [];
@@ -268,7 +268,7 @@ export class WsClient extends Client implements SqlOwner {
             } else {
                 throw impossible(encoding, "Impossible encoding");
             }
-            
+
             this.#handleMsg(msg);
         } catch (e) {
             this.#socket.close(3007, "Could not handle message");

--- a/src/ws/stream.ts
+++ b/src/ws/stream.ts
@@ -47,7 +47,7 @@ export class WsStream extends Stream {
 
     /** @private */
     constructor(client: WsClient, streamId: number) {
-        super(client.intMode);
+        super(client.intMode, client.config);
         this.#client = client;
         this.#streamId = streamId;
 


### PR DESCRIPTION
This PR was instigated due to my [Discord post](https://discord.com/channels/933071162680958986/1234527248565014548/1234527248565014548) and my involvement of [this Kysely GitHub issue](https://github.com/kysely-org/kysely/issues/123#issuecomment-2085380537). In short: after switching from PlanetScale to Turso I was expecting boolean DB values that I fetch in my program to be actual booleans, but they weren't! I learned that SQLite saves booleans as integers, and hrana doesn't cast them to booleans.

As a workaround, I then [forked](https://www.npmjs.com/package/@voinik/kysely-libsql) the @libsql/kysely-libsql Kysely driver to get it to pass hrana/libsql's selected column data so that I could write a Kysely plugin that can do the cast in my own application code. The plugin can be found in the README of my fork, if anyone's interested.

But this led me to wonder why hrana isn't doing that cast. When data is inserted (updates/creates), JS booleans are in fact cast to integers/bigints prior to insertion. I would expect this to be done the in other direction as well. Considering hrana is already going through all the columns in the query results, it seemed like unnecessary overhead to then do that again in the developer's application code. And thus this PR was born.

I've basically added an optional config parameter that has an optional `castBooleans` property, for backwards compatibility. You can even use it to pass down other configuration in the future.

I got this working with the different @libsql/libsql-client-ts clients with a few minor adjustments (passing the config down where needed, about 25 lines of changes in that repo in total).

Please let me know what you think!

Edit: I just now changed all my tables to STRICT. The issue with that is that we are no longer allowed to use other data types than INT, INTEGER, BLOB, TEXT, REAL and ANY. So `boolean` isn't allowed. This makes my solution unusable for STRICT tables. I also noticed my solution (for now) only works if the column type was set to 'boolean', meaning it won't work for 'bool', for example; perhaps a `.contains('bool')` would suffice. Anyway, feel free to close this PR if you think there are too many conditions for this to work.