### PR TITLE
Upgrade @libsql/isomorphic-fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.6.2",
       "license": "MIT",
       "dependencies": {
-        "@libsql/isomorphic-fetch": "^0.2.2",
+        "@libsql/isomorphic-fetch": "^0.2.3",
         "@libsql/isomorphic-ws": "^0.1.5",
         "js-base64": "^3.7.5",
         "node-fetch": "^3.3.2"
@@ -1015,9 +1015,9 @@
       }
     },
     "node_modules/@libsql/isomorphic-fetch": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@libsql/isomorphic-fetch/-/isomorphic-fetch-0.2.2.tgz",
-      "integrity": "sha512-xGN22unSkzfllb5ztjxweWoft3ysJgf4A4O0v8iiX/M+SPzHqBcIhoLbGhk7s3n5ZtOWCEf6ugGPfqpY6p08kQ==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@libsql/isomorphic-fetch/-/isomorphic-fetch-0.2.3.tgz",
+      "integrity": "sha512-WUc3wVcAo1ZpTulhKHRx8OGVWU9qu/zV9rPXmxncG+258zf/wZHi1g7KFK8LOuD98WDLjWcJF6xOTZgwdEH1sQ==",
       "engines": {
         "node": ">=18.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.6.2",
       "license": "MIT",
       "dependencies": {
-        "@libsql/isomorphic-fetch": "^0.2.1",
+        "@libsql/isomorphic-fetch": "^0.2.2",
         "@libsql/isomorphic-ws": "^0.1.5",
         "js-base64": "^3.7.5",
         "node-fetch": "^3.3.2"
@@ -1015,9 +1015,12 @@
       }
     },
     "node_modules/@libsql/isomorphic-fetch": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@libsql/isomorphic-fetch/-/isomorphic-fetch-0.2.1.tgz",
-      "integrity": "sha512-Sv07QP1Aw8A5OOrmKgRUBKe2fFhF2hpGJhtHe3d1aRnTESZCGkn//0zDycMKTGamVWb3oLYRroOsCV8Ukes9GA=="
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@libsql/isomorphic-fetch/-/isomorphic-fetch-0.2.2.tgz",
+      "integrity": "sha512-xGN22unSkzfllb5ztjxweWoft3ysJgf4A4O0v8iiX/M+SPzHqBcIhoLbGhk7s3n5ZtOWCEf6ugGPfqpY6p08kQ==",
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/@libsql/isomorphic-ws": {
       "version": "0.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.6.2",
       "license": "MIT",
       "dependencies": {
-        "@libsql/isomorphic-fetch": "^0.2.3",
+        "@libsql/isomorphic-fetch": "^0.2.4",
         "@libsql/isomorphic-ws": "^0.1.5",
         "js-base64": "^3.7.5",
         "node-fetch": "^3.3.2"
@@ -1015,9 +1015,9 @@
       }
     },
     "node_modules/@libsql/isomorphic-fetch": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@libsql/isomorphic-fetch/-/isomorphic-fetch-0.2.3.tgz",
-      "integrity": "sha512-WUc3wVcAo1ZpTulhKHRx8OGVWU9qu/zV9rPXmxncG+258zf/wZHi1g7KFK8LOuD98WDLjWcJF6xOTZgwdEH1sQ==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@libsql/isomorphic-fetch/-/isomorphic-fetch-0.2.4.tgz",
+      "integrity": "sha512-FaL5BAaoEsBklY8SkvzOUzqnHH4n2MeabZhihviTrZDNDPR890XXryuHXk/arOcmpIAPbvds7GjnwVFVXZwh6w==",
       "engines": {
         "node": ">=18.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "typedoc": "rm -rf ./docs && typedoc"
   },
   "dependencies": {
-    "@libsql/isomorphic-fetch": "^0.2.1",
+    "@libsql/isomorphic-fetch": "^0.2.2",
     "@libsql/isomorphic-ws": "^0.1.5",
     "js-base64": "^3.7.5",
     "node-fetch": "^3.3.2"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "typedoc": "rm -rf ./docs && typedoc"
   },
   "dependencies": {
-    "@libsql/isomorphic-fetch": "^0.2.2",
+    "@libsql/isomorphic-fetch": "^0.2.3",
     "@libsql/isomorphic-ws": "^0.1.5",
     "js-base64": "^3.7.5",
     "node-fetch": "^3.3.2"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "typedoc": "rm -rf ./docs && typedoc"
   },
   "dependencies": {
-    "@libsql/isomorphic-fetch": "^0.2.3",
+    "@libsql/isomorphic-fetch": "^0.2.4",
     "@libsql/isomorphic-ws": "^0.1.5",
     "js-base64": "^3.7.5",
     "node-fetch": "^3.3.2"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "typedoc": "rm -rf ./docs && typedoc"
   },
   "dependencies": {
-    "@libsql/isomorphic-fetch": "^0.2.4",
+    "@libsql/isomorphic-fetch": "0.2.4",
     "@libsql/isomorphic-ws": "^0.1.5",
     "js-base64": "^3.7.5",
     "node-fetch": "^3.3.2"


### PR DESCRIPTION
`@libsql/isomorphic-fetch` version `0.2.2` includes changes from https://github.com/libsql/isomorphic-ts/pull/11 so we're upgrading the version we use in this package.