### PR TITLE
upgrade isomorphic-fetch: 0.2.5 -> 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.0 -- 2024-09-16
+
+- Upgrade isomorphic-fetch to v0.3.0 which do not override `fetch` agent and do not have issue with headers in cloud providers (see https://github.com/libsql/isomorphic-ts/pull/17)
+
 ## 0.6.3 -- 2024-08-25
 
 - Make sure fetch response body is read or cancelled during flush, which fixes random networking errors observed by users.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
-        "@libsql/isomorphic-fetch": "^0.3.0",
+        "@libsql/isomorphic-fetch": "^0.3.1",
         "@libsql/isomorphic-ws": "^0.1.5",
         "js-base64": "^3.7.5",
         "node-fetch": "^3.3.2"
@@ -1015,10 +1015,9 @@
       }
     },
     "node_modules/@libsql/isomorphic-fetch": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@libsql/isomorphic-fetch/-/isomorphic-fetch-0.3.0.tgz",
-      "integrity": "sha512-GwBtp0WLRfKiJVQQy34kko+CKZCV9thBvP3DVZDva8jm0jFYRopyH+uQm//FgQCb1+6BmFQdKQ+7TLR23+zzIA==",
-      "license": "MIT",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@libsql/isomorphic-fetch/-/isomorphic-fetch-0.3.1.tgz",
+      "integrity": "sha512-6kK3SUK5Uu56zPq/Las620n5aS9xJq+jMBcNSOmjhNf/MUvdyji4vrMTqD7ptY7/4/CAVEAYDeotUz60LNQHtw==",
       "engines": {
         "node": ">=18.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@libsql/hrana-client",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@libsql/hrana-client",
-      "version": "0.6.3",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
-        "@libsql/isomorphic-fetch": "^0.2.1",
+        "@libsql/isomorphic-fetch": "^0.3.0",
         "@libsql/isomorphic-ws": "^0.1.5",
         "js-base64": "^3.7.5",
         "node-fetch": "^3.3.2"
@@ -1015,9 +1015,13 @@
       }
     },
     "node_modules/@libsql/isomorphic-fetch": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@libsql/isomorphic-fetch/-/isomorphic-fetch-0.2.1.tgz",
-      "integrity": "sha512-Sv07QP1Aw8A5OOrmKgRUBKe2fFhF2hpGJhtHe3d1aRnTESZCGkn//0zDycMKTGamVWb3oLYRroOsCV8Ukes9GA=="
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@libsql/isomorphic-fetch/-/isomorphic-fetch-0.3.0.tgz",
+      "integrity": "sha512-GwBtp0WLRfKiJVQQy34kko+CKZCV9thBvP3DVZDva8jm0jFYRopyH+uQm//FgQCb1+6BmFQdKQ+7TLR23+zzIA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/@libsql/isomorphic-ws": {
       "version": "0.1.5",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "typedoc": "rm -rf ./docs && typedoc"
   },
   "dependencies": {
-    "@libsql/isomorphic-fetch": "^0.3.0",
+    "@libsql/isomorphic-fetch": "^0.3.1",
     "@libsql/isomorphic-ws": "^0.1.5",
     "js-base64": "^3.7.5",
     "node-fetch": "^3.3.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@libsql/hrana-client",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "keywords": [
     "hrana",
     "libsql",
@@ -45,7 +45,7 @@
     "typedoc": "rm -rf ./docs && typedoc"
   },
   "dependencies": {
-    "@libsql/isomorphic-fetch": "^0.2.1",
+    "@libsql/isomorphic-fetch": "^0.3.0",
     "@libsql/isomorphic-ws": "^0.1.5",
     "js-base64": "^3.7.5",
     "node-fetch": "^3.3.2"


### PR DESCRIPTION
Upgrade isomorphic fetch to v0.3.1 where we no longer override fetch agent and do not have issue with missing headers (see https://github.com/libsql/isomorphic-ts/pull/17)