### PR TITLE
replace @libsql/isomorphic-fetch with cross-fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.0 -- 2024-09-16
+
+- Replace isomorphic-fetch dependency with cross-fetch
+
 ## 0.7.0 -- 2024-09-16
 
 - Upgrade isomorphic-fetch to v0.3.0 which do not override `fetch` agent and do not have issue with headers in cloud providers (see https://github.com/libsql/isomorphic-ts/pull/17)

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
-        "@libsql/isomorphic-fetch": "^0.3.1",
         "@libsql/isomorphic-ws": "^0.1.5",
+        "cross-fetch": "^4.0.0",
         "js-base64": "^3.7.5",
         "node-fetch": "^3.3.2"
       },
@@ -1014,14 +1014,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@libsql/isomorphic-fetch": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@libsql/isomorphic-fetch/-/isomorphic-fetch-0.3.1.tgz",
-      "integrity": "sha512-6kK3SUK5Uu56zPq/Las620n5aS9xJq+jMBcNSOmjhNf/MUvdyji4vrMTqD7ptY7/4/CAVEAYDeotUz60LNQHtw==",
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@libsql/isomorphic-ws": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/@libsql/isomorphic-ws/-/isomorphic-ws-0.1.5.tgz",
@@ -1561,6 +1553,35 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
+    },
+    "node_modules/cross-fetch": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
+      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.6.12"
+      }
+    },
+    "node_modules/cross-fetch/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -3553,6 +3574,12 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/ts-jest": {
       "version": "29.1.1",
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.1.1.tgz",
@@ -3785,6 +3812,22 @@
       "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@libsql/hrana-client",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@libsql/hrana-client",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "@libsql/isomorphic-ws": "^0.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@libsql/hrana-client",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "keywords": [
     "hrana",
     "libsql",

--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
     "typedoc": "rm -rf ./docs && typedoc"
   },
   "dependencies": {
-    "@libsql/isomorphic-fetch": "^0.3.1",
     "@libsql/isomorphic-ws": "^0.1.5",
+    "cross-fetch": "^4.0.0",
     "js-base64": "^3.7.5",
     "node-fetch": "^3.3.2"
   },

--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -1,5 +1,5 @@
-import type { Response } from "@libsql/isomorphic-fetch";
-import { fetch, Request } from "@libsql/isomorphic-fetch";
+import type { Response } from "cross-fetch";
+import { fetch, Request } from "cross-fetch";
 
 import * as hrana from "..";
 

--- a/src/http/client.ts
+++ b/src/http/client.ts
@@ -1,4 +1,4 @@
-import { fetch, Request } from "@libsql/isomorphic-fetch";
+import { fetch, Request } from "cross-fetch";
 
 import type { ProtocolVersion, ProtocolEncoding } from "../client.js";
 import { Client } from "../client.js";

--- a/src/http/cursor.ts
+++ b/src/http/cursor.ts
@@ -1,4 +1,4 @@
-import type { Response, ReadableStreamDefaultReader } from "@libsql/isomorphic-fetch";
+import type { Response } from "cross-fetch";
 
 import { ByteQueue } from "../byte_queue.js";
 import type { ProtocolEncoding } from "../client.js";
@@ -79,7 +79,7 @@ export class HttpCursor extends Cursor {
     }
 
     async #nextItem<T>(jsonFun: jsond.ObjectFun<T>, protobufDef: protobufd.MessageDef<T>): Promise<T | undefined> {
-        for (;;) {
+        for (; ;) {
             if (this.#done) {
                 return undefined;
             } else if (this.#closed !== undefined) {
@@ -106,7 +106,7 @@ export class HttpCursor extends Cursor {
                 throw new InternalError("Attempted to read from HTTP cursor before it was opened");
             }
 
-            const {value, done} = await this.#reader.read();
+            const { value, done } = await this.#reader.read();
             if (done && this.#queue.length === 0) {
                 this.#done = true;
             } else if (done) {
@@ -135,12 +135,12 @@ export class HttpCursor extends Cursor {
 
         let varintValue = 0;
         let varintLength = 0;
-        for (;;) {
+        for (; ;) {
             if (varintLength >= data.byteLength) {
                 return undefined;
             }
             const byte = data[varintLength];
-            varintValue |= (byte & 0x7f) << (7*varintLength);
+            varintValue |= (byte & 0x7f) << (7 * varintLength);
             varintLength += 1;
             if (!(byte & 0x80)) {
                 break;

--- a/src/http/stream.ts
+++ b/src/http/stream.ts
@@ -1,5 +1,5 @@
-import type { fetch, Response } from "@libsql/isomorphic-fetch";
-import { Request, Headers } from "@libsql/isomorphic-fetch";
+import type { fetch } from "cross-fetch";
+import { Request, Headers } from "cross-fetch";
 
 import type { ProtocolEncoding } from "../client.js";
 import type { Cursor } from "../cursor.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,8 +8,8 @@ import { WsClient } from "./ws/client.js";
 import { ProtocolVersion } from "./client.js";
 
 export { WebSocket } from "@libsql/isomorphic-ws";
-export type { RequestInit, Response } from "@libsql/isomorphic-fetch";
-export { fetch, Request, Headers } from "@libsql/isomorphic-fetch";
+export type { Response } from "cross-fetch";
+export { fetch, Request, Headers } from "cross-fetch";
 
 export type { ProtocolVersion, ProtocolEncoding } from "./client.js";
 export { Client } from "./client.js";
@@ -49,8 +49,8 @@ export function openWs(url: string | URL, jwt?: string, protocolVersion: Protoco
 /** Open a Hrana client over HTTP connected to the given `url`.
  *
  * If the `customFetch` argument is passed and not `undefined`, it is used in place of the `fetch` function
- * from `@libsql/isomorphic-fetch`. This function is always called with a `Request` object from
- * `@libsql/isomorphic-fetch`.
+ * from `cross-fetch`. This function is always called with a `Request` object from
+ * `cross-fetch`.
  */
 export function openHttp(url: string | URL, jwt?: string, customFetch?: unknown | undefined, protocolVersion: ProtocolVersion = 2): HttpClient {
     return new HttpClient(url instanceof URL ? url : new URL(url), jwt, customFetch, protocolVersion);


### PR DESCRIPTION
`@libsql/isomorphic-fetch` is weird dependency which we do not properly maintain. For example, for now it uses "web" types in the node context and create issues with `undici` HTTP client.

This PR completely remove `@libsql/isomorphic-fetch` in favour of well maintained [`cross-fetch`](https://www.npmjs.com/package/cross-fetch) library.

We expect increase in bundle size as `cross-fetch` explicitly depends on the `node-fetch` (`@libsql/isomorphic-fetch` - [230B minified](https://bundlephobia.com/package/@libsql/isomorphic-fetch@0.3.1), `cross-fetch - [9.8KB minified](https://bundlephobia.com/package/cross-fetch@4.0.0)). This increase comes in exchange for safety and stability of our hrana client.