### PR TITLE
Remove cross-fetch dependency in favor of native fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -133,7 +133,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.10.tgz",
       "integrity": "sha512-fTmqbbUBAwCcre6zPzNngvsI0aNrPZe77AeqvDxWM9Nm+04RrJ3CAmGHA9f7lJQY6ZMhRztNemy4uslDxTX4Qw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.22.10",
@@ -1371,7 +1370,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001517",
         "electron-to-chromium": "^1.4.477",
@@ -2165,7 +2163,6 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.6.2.tgz",
       "integrity": "sha512-8eQg2mqFbaP7CwfsTpCxQ+sHzw1WuNWL5UUvjnWP4hx2riGz9fPSzYOaU5q8/GqWn1TfgZIVTqYJygbGbWAANg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.6.2",
         "@jest/types": "^29.6.1",
@@ -3730,7 +3727,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
       "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -46,9 +46,7 @@
   },
   "dependencies": {
     "@libsql/isomorphic-ws": "^0.1.5",
-    "cross-fetch": "^4.0.0",
-    "js-base64": "^3.7.5",
-    "node-fetch": "^3.3.2"
+    "js-base64": "^3.7.5"
   },
   "devDependencies": {
     "@types/jest": "^29",

--- a/src/__tests__/client.ts
+++ b/src/__tests__/client.ts
@@ -1,6 +1,3 @@
-import type { Response } from "cross-fetch";
-import { fetch, Request } from "cross-fetch";
-
 import * as hrana from "..";
 
 const url = process.env.URL ?? "ws://localhost:8080";

--- a/src/http/client.ts
+++ b/src/http/client.ts
@@ -1,5 +1,3 @@
-import { fetch, Request } from "cross-fetch";
-
 import type { ProtocolVersion, ProtocolEncoding } from "../client.js";
 import { Client } from "../client.js";
 import { ClientError, ClosedError, ProtocolVersionError } from "../errors.js";
@@ -45,7 +43,7 @@ const fallbackEndpoint: Endpoint = {
 export class HttpClient extends Client {
     #url: URL;
     #jwt: string | undefined;
-    #fetch: typeof fetch;
+    #fetch: typeof globalThis.fetch;
     #remoteEncryptionKey: string | undefined;
 
     #closed: Error | undefined;
@@ -61,7 +59,7 @@ export class HttpClient extends Client {
         super();
         this.#url = url;
         this.#jwt = jwt;
-        this.#fetch = (customFetch as typeof fetch) ?? fetch;
+        this.#fetch = (customFetch as typeof globalThis.fetch) ?? globalThis.fetch;
         this.#remoteEncryptionKey = remoteEncryptionKey;
 
         this.#closed = undefined;
@@ -145,7 +143,7 @@ export class HttpClient extends Client {
     }
 }
 
-async function findEndpoint(customFetch: typeof fetch, clientUrl: URL): Promise<Endpoint> {
+async function findEndpoint(customFetch: typeof globalThis.fetch, clientUrl: URL): Promise<Endpoint> {
     const fetch = customFetch;
     for (const endpoint of checkEndpoints) {
         const url = new URL(endpoint.versionPath, clientUrl);

--- a/src/http/cursor.ts
+++ b/src/http/cursor.ts
@@ -1,5 +1,3 @@
-import type { Response } from "cross-fetch";
-
 import { ByteQueue } from "../byte_queue.js";
 import type { ProtocolEncoding } from "../client.js";
 import { Cursor } from "../cursor.js";

--- a/src/http/stream.ts
+++ b/src/http/stream.ts
@@ -1,6 +1,3 @@
-import type { fetch } from "cross-fetch";
-import { Request, Headers } from "cross-fetch";
-
 import type { ProtocolEncoding } from "../client.js";
 import type { Cursor } from "../cursor.js";
 import type * as jsone from "../encoding/json/encode.js";
@@ -52,7 +49,7 @@ export class HttpStream extends Stream implements SqlOwner {
     #client: HttpClient;
     #baseUrl: string;
     #jwt: string | undefined;
-    #fetch: typeof fetch;
+    #fetch: typeof globalThis.fetch;
     #remoteEncryptionKey: string | undefined;
 
     #baton: string | undefined;
@@ -66,7 +63,7 @@ export class HttpStream extends Stream implements SqlOwner {
     #sqlIdAlloc: IdAlloc;
 
     /** @private */
-    constructor(client: HttpClient, baseUrl: URL, jwt: string | undefined, customFetch: typeof fetch, remoteEncryptionKey?: string) {
+    constructor(client: HttpClient, baseUrl: URL, jwt: string | undefined, customFetch: typeof globalThis.fetch, remoteEncryptionKey?: string) {
         super(client.intMode);
         this.#client = client;
         this.#baseUrl = baseUrl.toString();

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,8 +8,6 @@ import { WsClient } from "./ws/client.js";
 import { ProtocolVersion } from "./client.js";
 
 export { WebSocket } from "@libsql/isomorphic-ws";
-export type { Response } from "cross-fetch";
-export { fetch, Request, Headers } from "cross-fetch";
 
 export type { ProtocolVersion, ProtocolEncoding } from "./client.js";
 export { Client } from "./client.js";
@@ -49,8 +47,7 @@ export function openWs(url: string | URL, jwt?: string, protocolVersion: Protoco
 /** Open a Hrana client over HTTP connected to the given `url`.
  *
  * If the `customFetch` argument is passed and not `undefined`, it is used in place of the `fetch` function
- * from `cross-fetch`. This function is always called with a `Request` object from
- * `cross-fetch`.
+ * from the global `fetch`. This function is always called with a global `Request` object.
  */
 export function openHttp(url: string | URL, jwt?: string, customFetch?: unknown | undefined, remoteEncryptionKey?: string, protocolVersion: ProtocolVersion = 2): HttpClient {
     return new HttpClient(url instanceof URL ? url : new URL(url), jwt, customFetch, remoteEncryptionKey, protocolVersion);

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "moduleResolution": "node",
-        "lib": ["esnext"],
+        "lib": ["esnext", "DOM"],
         "target": "esnext",
 
         "esModuleInterop": true,


### PR DESCRIPTION
Closes issue #23

## Background

PR #20 replaced `@libsql/isomorphic-fetch` with `cross-fetch` for stability. Since then, the landscape has changed:

- Node 18+ ships native `fetch`, `Request`, `Headers`, and `Response` as globals
- Node 16 reached EOL in Sep 2023; Node 18 reached EOL in Apr 2025
- The `cross-fetch` CJS entry pulls in `node-fetch@2`, which depends on `whatwg-url@5` and `tr46@0.0.3` - both of which `require("punycode")`, triggering [DEP0040](https://nodejs.org/api/deprecations.html#DEP0040) on Node 21+
- `node-fetch@3` depends on `node-domexception`, which is itself deprecated

The polyfill chain that `cross-fetch` provides is no longer needed on any supported Node version.

## Changes

- Removed `cross-fetch` and `node-fetch` from dependencies
- Replaced all `cross-fetch` imports with native global references (`globalThis.fetch`, `Request`, `Headers`, `Response`)
- Added `"DOM"` to the TypeScript `lib` array in `tsconfig.base.json` to provide types for the web fetch API
- Updated `customFetch` fallback in `HttpClient` to default to `globalThis.fetch`

## Breaking changes

- `fetch`, `Request`, `Headers`, and `Response` were previously re-exported from the package entry point (`index.ts`). These re-exports are removed. Consumers who imported fetch primitives from `@libsql/hrana-client` will need to use `globalThis` directly instead. This is unlikely to affect real-world usage since these are standard globals.
- Environments without a native `fetch` global (Node < 18) are no longer supported. The `customFetch` parameter on `openHttp()` remains available as an escape hatch for non-standard runtimes.

## Reproduction

The deprecation can be demonstrated with a minimal repro. Both scripts hook `Module._load` to trace which files pull in `punycode`, then load hrana-client.

### Setup

```json
// package.json
{
  "name": "hrana-client-punycode-repro",
  "private": true,
  "description": "Reproduces the punycode deprecation warning from @libsql/hrana-client",
  "scripts": {
    "before": "node --trace-deprecation repro-before.cjs",
    "after": "node --trace-deprecation repro-after.cjs"
  },
  "dependencies": {
    "@libsql/hrana-client": "0.9.0"
  }
}
```

### Before (v0.9.0 from npm - triggers DEP0040)

```js
// repro-before.cjs
// Run with: node --trace-deprecation repro-before.cjs

const Module = require("module");
const origLoad = Module._load;
Module._load = function (request, parent, isMain) {
  if (request === "punycode") {
    console.log(`  [trace] punycode required by: ${parent?.filename}`);
  }
  return origLoad.apply(this, arguments);
};

console.log("Loading @libsql/hrana-client@0.9.0 from npm...");
require("@libsql/hrana-client");
console.log("Done.");
```

Output:

```bash
Loading @libsql/hrana-client@0.9.0 from npm...
  [trace] punycode required by: .../whatwg-url/lib/url-state-machine.js
  [trace] punycode required by: .../tr46/index.js
Done.
(node:23944) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
    at node:punycode:7:10
    at BuiltinModule.compileForInternalLoader (node:internal/bootstrap/realm:398:7)
    at BuiltinModule.compileForPublicLoader (node:internal/bootstrap/realm:337:10)
    at loadBuiltinModule (node:internal/modules/helpers:125:7)
    at loadBuiltinWithHooks (node:internal/modules/cjs/loader:1202:15)
    at Module.<anonymous> (node:internal/modules/cjs/loader:1293:48)
    ...
```

### After (local build with cross-fetch removed - clean)

```js
// repro-after.cjs
// Run with: node --trace-deprecation repro-after.cjs
//
// Requires a local build of hrana-client-ts with cross-fetch removed,
// placed at ../hrana-client-ts/lib-cjs/index.js relative to this script.

const Module = require("module");
const origLoad = Module._load;
Module._load = function (request, parent, isMain) {
  if (request === "punycode") {
    console.log(`  [trace] punycode required by: ${parent?.filename}`);
  }
  return origLoad.apply(this, arguments);
};

console.log("Loading @libsql/hrana-client from local build...");
require("../hrana-client-ts/lib-cjs/index.js");
console.log("Done.");
```

Output:

```bash
Loading @libsql/hrana-client from local build...
Done.
```

No punycode warning, no deprecation.

## Checklist

- [x] `tsc --noEmit` passes clean
- [x] `npm run build` succeeds (both CJS and ESM targets)
- [x] Integration tests against Turso - results identical to `main` branch (see below)

## Test results

Ran the integration test suite against a Turso database over HTTP (`--testTimeout=30000`):

| | `main` (unmodified) | `remove-cross-fetch` |
| --- | --- | --- |
| Passed | 75 | 80 |
| Failed | 8 | 3 |
| Skipped | 22 | 22 |

The 5-test improvement with longer timeout is expected - remote Turso has higher latency than local sqld, and the default 5s timeout was too tight.

The 3 remaining failures are pre-existing and identical on both branches:

| Test | Behavior |
| --- | --- |
| `concurrent operations are correctly ordered` | Fails even in isolation - appears to be a test bug |
| `batches are executed sequentially` | Times out at 30s even in isolation - too slow for remote |
| `many stream operations > immediately after each other` | Passes in isolation, fails in suite (cross-test contamination) |

None of the failures are related to this change.

## How to test

1. **Typecheck:** `npx tsc --noEmit`
2. **Build:** `npm run build`
3. **Deprecation warning gone:** Create the repro scripts above, run `node --trace-deprecation repro-before.cjs` (warning present with v0.9.0 from npm) and `node --trace-deprecation repro-after.cjs` (clean with this branch's build)
4. **Integration against Turso:** `URL="https://<db>.turso.io" JWT="<token>" npx jest --runInBand --testTimeout=30000`
5. **Integration against local sqld:** `URL=http://localhost:8080 npm test`

## Further comments

This is the inverse of PR #20, which added `cross-fetch` to replace `@libsql/isomorphic-fetch`. At the time, cross-fetch provided stability over the unmaintained isomorphic-fetch. Now that every supported Node version (20+) has native fetch, the polyfill is pure cost:

- **9.8 KB** of minified bundle weight (cross-fetch + node-fetch + transitive deps)
- Deprecation warnings from `punycode` (DEP0040) and `node-domexception`
- A `node-fetch@2` code path in CJS that diverges from the native fetch spec (e.g., incomplete `ReadableStream` support, as noted in `cursor.ts`)

The `customFetch` parameter on `openHttp()` is preserved, so consumers in non-standard environments can still inject their own implementation.